### PR TITLE
Request ajax() changed to wantsJson()

### DIFF
--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -54,7 +54,7 @@ class DataGrid
     {
         $request = request();
 
-        if ($request->ajax()) {
+        if ($request->wantsJson()) {
             $paginator = $this->search($request->search)
                         ->sort($request->order, $request->dir)
                         ->paginate($request->limit);


### PR DESCRIPTION
`$request->ajax()` required `window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'`

`$request->wantsJson()` does not need this header and works better.